### PR TITLE
docs: update IntelliSense setup for Tailwind Variants

### DIFF
--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -115,15 +115,17 @@ To enable autocompletion for **Tailwind Variants** you can follow the instructio
 
 <Tabs items={['VSCode', 'Neovim', 'IntelliJ']}>
   <Tab>
-    If you are using **VSCode** and the [**TailwindCSS IntelliSense Extension**](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss), you have to add the following to your `settings.json` file.
+     If you are using **VSCode** and the [**TailwindCSS IntelliSense Extension**](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss), you can enable autocompletion for Tailwind Variants by adding the following to your `settings.json` file. 
 
     ```json copy
     {
-      "tailwindCSS.experimental.classRegex": [
-        ["([\"'`][^\"'`]*.*?[\"'`])", "[\"'`]([^\"'`]*).*?[\"'`]"]
-      ]
+      "tailwindCSS.classFunctions": ["tv"]
     }
     ```
+
+This configuration replaces the older approach where you needed to use tailwindCSS.experimental.classRegex. The new method is simpler and enables autocompletion for Tailwind Variants with just the classFunctions setting.
+
+For more information, check the official Tailwind CSS IntelliSense Documentation. </Tab>
 
   </Tab>
   <Tab>


### PR DESCRIPTION
This commit updates the setup instructions for enabling autocompletion for Tailwind Variants in VSCode. Previously, the setup required adding tailwindCSS.experimental.classRegex to the settings.json file, but with the newer versions of the Tailwind CSS IntelliSense extension, users can now simply add "tailwindCSS.classFunctions": ["tv"] to their settings.json file. This change simplifies the configuration, removing the need for complex regular expressions.

This update also resolves the issue discussed in #247, where users were facing difficulties with the previous configuration. The new method provides a much more straightforward way of enabling autocompletion for Tailwind Variants.